### PR TITLE
Properly formatted shell script

### DIFF
--- a/boot-os.sh
+++ b/boot-os.sh
@@ -1,1 +1,3 @@
-qemu-system-x86_64 -bios "OVMF.fd" -drive file=fat:rw:.,format=raw 2>nul
+#! /bin/bash
+
+qemu-system-x86_64 -bios "OVMF.fd" -drive file=fat:rw:.,format=raw 2>/dev/null


### PR DESCRIPTION
The output of `stderr` was meant to be discarded based on boot-os.bat. Changed to properly discard.

Also added the bash shebang.